### PR TITLE
.gitignore: add .bak and .sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,8 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+# Text backup files
+*.bak
+
+# Database
+*.sqlite3


### PR DESCRIPTION
This commit adds entries for .bak and .sqlite3 files to the .gitignore file. Ignoring these files ensures that they are not tracked by Git, preventing them from being accidentally committed to the repository. This is useful for excluding backup and database files that are generated during development and should not be version-controlled.